### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ class Logger(object):
         self.log_file = open(path, mode=mode)
         self.logger = csv.writer(self.log_file, delimiter='\t')
 
-        if mode is not 'a':
+        if mode != 'a':
             self.logger.writerow(header)
 
         self.header = header


### PR DESCRIPTION
flake8 testing of https://github.com/iduta/pyconv on Python 3.8.3

% __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./utils.py:10:12: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
        if mode is not 'a':
           ^
./models/resnet.py:15:1: F822 undefined name 'resnet200' in __all__
__all__ = ['ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101',
^
1     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
1     F822 undefined name 'resnet200' in __all__
2
```